### PR TITLE
Fix the copyright section in the docs.

### DIFF
--- a/docs/beta.md
+++ b/docs/beta.md
@@ -73,36 +73,34 @@
 > Link: https://github.com/mapsforge/mapsforge/blob/master/docs/Getting-Started-Map-Writer.md
 
 ### 地圖版權與散佈說明
-<pre>
-Copyright (c) 2016 Rudy Chung
-All rights reserved.
+    Copyright (c) 2016-2019 Rudy Chung
+    All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
 
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
+        * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
 
-    * Redistributions in binary form must reproduce the this copyright notice
-    (or the HTTP link to this notice), this list of conditions and the
-    following disclaimer in the documentation and/or other materials provided
-    with the distribution.
+        * Redistributions in binary form must reproduce the this copyright notice
+        (or the HTTP link to this notice), this list of conditions and the
+        following disclaimer in the documentation and/or other materials provided
+        with the distribution.
 
-    * Redistributions with modification must use a different map name which
-    could be easily and clearly to be distinguished with this map.
+        * Redistributions with modification must use a different map name which
+        could be easily and clearly to be distinguished with this map.
 
-    * Neither the name of Rudy Chung nor the names of its contributors may be
-    used to endorse or promote products derived from this software without 
-    specific prior written permission.
+        * Neither the name of Rudy Chung nor the names of its contributors may be
+        used to endorse or promote products derived from this software without 
+        specific prior written permission.
 
-THIS MAP IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL RUDY BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-MAP, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre>
+    THIS MAP IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL RUDY BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    MAP, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/local.md
+++ b/docs/local.md
@@ -150,36 +150,34 @@
 
 
 ## 地圖版權與散佈說明
-<pre>
-Copyright (c) 2016 Rudy Chung
-All rights reserved.
+    Copyright (c) 2016-2019 Rudy Chung
+    All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
 
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
+        * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
 
-    * Redistributions in binary form must reproduce the this copyright notice
-    (or the HTTP link to this notice), this list of conditions and the
-    following disclaimer in the documentation and/or other materials provided
-    with the distribution.
+        * Redistributions in binary form must reproduce the this copyright notice
+        (or the HTTP link to this notice), this list of conditions and the
+        following disclaimer in the documentation and/or other materials provided
+        with the distribution.
 
-    * Redistributions with modification must use a different map name which
-    could be easily and clearly to be distinguished with this map.
+        * Redistributions with modification must use a different map name which
+        could be easily and clearly to be distinguished with this map.
 
-    * Neither the name of Rudy Chung nor the names of its contributors may be
-    used to endorse or promote products derived from this software without 
-    specific prior written permission.
+        * Neither the name of Rudy Chung nor the names of its contributors may be
+        used to endorse or promote products derived from this software without 
+        specific prior written permission.
 
-THIS MAP IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL RUDY BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-MAP, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre>
+    THIS MAP IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL RUDY BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    MAP, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/taiwan_topo.md
+++ b/docs/taiwan_topo.md
@@ -467,36 +467,34 @@ Style 由綬草北三兄與我共同設定，作為合適登山與尋寶（hikin
 
 
 ## 地圖版權與散佈說明
-<pre>
-Copyright (c) 2016 Rudy Chung
-All rights reserved.
+    Copyright (c) 2016-2019 Rudy Chung
+    All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
 
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
+        * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
 
-    * Redistributions in binary form must reproduce the this copyright notice
-    (or the HTTP link to this notice), this list of conditions and the
-    following disclaimer in the documentation and/or other materials provided
-    with the distribution.
+        * Redistributions in binary form must reproduce the this copyright notice
+        (or the HTTP link to this notice), this list of conditions and the
+        following disclaimer in the documentation and/or other materials provided
+        with the distribution.
 
-    * Redistributions with modification must use a different map name which
-    could be easily and clearly to be distinguished with this map.
+        * Redistributions with modification must use a different map name which
+        could be easily and clearly to be distinguished with this map.
 
-    * Neither the name of Rudy Chung nor the names of its contributors may be
-    used to endorse or promote products derived from this software without 
-    specific prior written permission.
+        * Neither the name of Rudy Chung nor the names of its contributors may be
+        used to endorse or promote products derived from this software without 
+        specific prior written permission.
 
-THIS MAP IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL RUDY BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-MAP, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre>
+    THIS MAP IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL RUDY BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    MAP, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Cloudflare will fix the syntax error of pre tag by changing the html content.
markdown/discount will generate right html tags as pre code when using tab.