### PR TITLE
Modify tag for mobile network provider

### DIFF
--- a/osm_scripts/process_osm.py
+++ b/osm_scripts/process_osm.py
@@ -91,9 +91,10 @@ class MapsforgeHandler(osmium.SimpleHandler):
 
     def handle_mobile_sign(self, n):
         tags = dict((tag.k, tag.v) for tag in n.tags)
+        operator_tag = 'internet_access:operator'
 
-        if tags.get('name') is None and tags.get('operator'):
-            operator = tags.get('operator')
+        if tags.get('name') is None and tags.get(operator_tag):
+            operator = tags.get(operator_tag)
             name = '通訊點 ('
 
             if '中華' in operator:
@@ -111,8 +112,8 @@ class MapsforgeHandler(osmium.SimpleHandler):
             name += ')'
             tags['name'] = name
 
-        if tags.get('name:en') is None and tags.get('operator'):
-            operator = tags.get('operator')
+        if tags.get('name:en') is None and tags.get(operator_tag):
+            operator = tags.get(operator_tag)
             name = 'mobile ('
             if '中華' in operator:
                 name += 'CHT,'
@@ -210,7 +211,7 @@ class MapsforgeHandler(osmium.SimpleHandler):
         if w.id in hknetworks and 'highway' in w.tags:
             self.handle_hknetwork(w)
             return
-        
+
         if w.id in national_park:
             self.handle_national_park(w)
             return


### PR DESCRIPTION
https://www.facebook.com/groups/taiwan.topo/permalink/1671496346339305
<details>
<summary>相關討論</summary>
<img src='https://user-images.githubusercontent.com/19887090/97826690-39629e00-1cfd-11eb-8bce-bba9f0356917.png' />
</details>  

將有關「林務局山區手機可通訊點標示 」的OSM標示，由目前的`operator`轉換為`internet_access:operator`

@alpha-rudy 
@kcwu 
Merge 之前，請使用以下的指令修改在OSM上的 tag
```bash
# 取得Makefile
LATEST_MAKEFILE=$(curl https://api.github.com/gists/11073025dc45ce5b5155d63fed031555 | jq -r .files.Makefile.raw_url)
curl -O $LATEST_MAKEFILE

# 即時取得目前有關的OSM nodes(information=mobile)，並產製Changeset
# 需要安裝yq，Mac 上可以使用 brew install python-yq 安裝
make && make changeset
```